### PR TITLE
Dashboard display params

### DIFF
--- a/underwater_rl/main.py
+++ b/underwater_rl/main.py
@@ -269,13 +269,13 @@ if __name__ == '__main__':
                         choices=['human', 'machine', 'none'],
                         help="Determine whether snell is visible to when rendering ('render') or to the agent and when"
                              "rendering ('machine')")
-    parser.add_argument('--ps', '--paddle-speed', default=3.0, type=float,
+    parser.add_argument('--paddle-speed', default=3.0, type=float,
                         help='paddle speed (default: 3.0)')
-    parser.add_argument('--pa', '--paddle-angle', default=45, type=float,
+    parser.add_argument('--paddle-angle', default=45, type=float,
                         help='Maximum angle the ball can leave the paddle (default: 45deg)')
-    parser.add_argument('--pl', '--paddle-length', default=45, type=int,
+    parser.add_argument('--paddle-length', default=45, type=int,
                         help='paddle length (default: 45)')
-    parser.add_argument('--lr', '--learning-rate', default=1e-4, type=float,
+    parser.add_argument('--learning-rate', default=1e-4, type=float,
                         help='learning rate (default: 1e-4)')
     parser.add_argument('--state', default='binary', type=str, choices=['binary', 'color'],
                         help='state representation (default: binary)')

--- a/underwater_rl/main.py
+++ b/underwater_rl/main.py
@@ -40,10 +40,10 @@ def select_action(state):
     sample = random.random()
     if STEPSDECAY:
         eps_threshold = EPS_END + (EPS_START - EPS_END) * \
-                    math.exp(-1. * steps_done / 1000000)
+                        math.exp(-1. * steps_done / 1000000)
     else:
         eps_threshold = EPS_END + (EPS_START - EPS_END) * \
-                    math.exp(-1. * epoch / EPS_DECAY)
+                        math.exp(-1. * epoch / EPS_DECAY)
 
     steps_done += 1
     if sample > eps_threshold:
@@ -132,7 +132,7 @@ def train(env, n_episodes, history, render=False):
     global epoch
     for episode in range(1, n_episodes + 1):
         obs = env.reset()
-        state = get_state(obs)      # torch.Size([1, 4, 84, 84])
+        state = get_state(obs)  # torch.Size([1, 4, 84, 84])
         total_reward = 0.0
         for t in count():
             action = select_action(state)
@@ -261,73 +261,76 @@ def get_args_status_string(parser: argparse.ArgumentParser, args: argparse.Names
 if __name__ == '__main__':
     # arguments
     parser = argparse.ArgumentParser(description='Dynamic Pong RL')
-    
+
     '''environment args'''
-    parser.add_argument('--width', default=160, type=int,
-                        help='canvas width (default: 160)')
-    parser.add_argument('--height', default=160, type=int,
-                        help='canvas height (default: 160)')
-    parser.add_argument('--ball', default=3.0, type=float,
-                        help='ball speed (default: 3.0)')
-    parser.add_argument('--ball-size', dest='ball_size', default=2.0, type=float,
-                        help='ball size (default: 2.0)')
-    parser.add_argument('--snell', default=3.0, type=float,
-                        help='snell speed (default: 3.0)')
-    parser.add_argument('--snell-width', dest='snell_width', default=40.0, type=float,
-                        help='snell speed (default: 40.0)')
-    parser.add_argument('--snell-change', dest='snell_change', default=0, type=float,
-                        help='Standard deviation of the speed change per step (default: 0)')
-    parser.add_argument('--snell-visible', dest='snell_visible', default='none', type=str,
-                        choices=['human', 'machine', 'none'],
-                        help="Determine whether snell is visible to when rendering ('render') or to the agent and when"
-                             "rendering ('machine')")
-    parser.add_argument('--paddle-speed', default=3.0, type=float,
-                        help='paddle speed (default: 3.0)')
-    parser.add_argument('--paddle-angle', default=45, type=float,
-                        help='Maximum angle the ball can leave the paddle (default: 45deg)')
-    parser.add_argument('--paddle-length', default=45, type=int,
-                        help='paddle length (default: 45)')
-    parser.add_argument('--update-prob', dest='update_prob', default=0.2, type=float,
-                        help='Probability that the opponent moves in the direction of the ball (default: 0.2)')
-    
+    env_args = parser.add_argument_group('Environment', "Environment controls")
+    env_args.add_argument('--width', default=160, type=int,
+                          help='canvas width (default: 160)')
+    env_args.add_argument('--height', default=160, type=int,
+                          help='canvas height (default: 160)')
+    env_args.add_argument('--ball', default=3.0, type=float,
+                          help='ball speed (default: 3.0)')
+    env_args.add_argument('--ball-size', dest='ball_size', default=2.0, type=float,
+                          help='ball size (default: 2.0)')
+    env_args.add_argument('--snell', default=3.0, type=float,
+                          help='snell speed (default: 3.0)')
+    env_args.add_argument('--snell-width', dest='snell_width', default=40.0, type=float,
+                          help='snell speed (default: 40.0)')
+    env_args.add_argument('--snell-change', dest='snell_change', default=0, type=float,
+                          help='Standard deviation of the speed change per step (default: 0)')
+    env_args.add_argument('--snell-visible', dest='snell_visible', default='none', type=str,
+                          choices=['human', 'machine', 'none'],
+                          help="Determine whether snell is visible to when rendering ('render') or to the agent and "
+                               "when rendering ('machine')")
+    env_args.add_argument('--paddle-speed', default=3.0, type=float,
+                          help='paddle speed (default: 3.0)')
+    env_args.add_argument('--paddle-angle', default=45, type=float,
+                          help='Maximum angle the ball can leave the paddle (default: 45deg)')
+    env_args.add_argument('--paddle-length', default=45, type=int,
+                          help='paddle length (default: 45)')
+    env_args.add_argument('--update-prob', dest='update_prob', default=0.2, type=float,
+                          help='Probability that the opponent moves in the direction of the ball (default: 0.2)')
+
     '''RL args'''
-    parser.add_argument('--learning-rate', default=1e-4, type=float,
-                        help='learning rate (default: 1e-4)')
-    parser.add_argument('--state', default='binary', type=str, choices=['binary', 'color'],
-                        help='state representation (default: binary)')
-    parser.add_argument('--network', default='dqn_pong_model',
-                        help='choose a network architecture (default: dqn_pong_model)')
-    parser.add_argument('--double', default=False, action='store_true',
-                        help='switch for double dqn (default: False)')
-    parser.add_argument('--pretrain', default=False, action='store_true',
-                        help='switch for pretrained network (default: False)')
-    parser.add_argument('--test', default=False, action='store_true',
-                        help='Run the model without training')
-    parser.add_argument('--render', default=False, type=str, choices=['human', 'png'],
-                        help="Rendering mode. Omit if no rendering is desired.")
-    parser.add_argument('--epsdecay', default=1000, type=int,
-                        help="epsilon decay (default: 1000)")
-    parser.add_argument('--stepsdecay', default=False, action='store_true',
-                        help="switch to use default step decay")
-    parser.add_argument('--episodes', dest='episodes', default=4000, type=int,
-                        help='Number of episodes to train for (default: 4000)')
-    parser.add_argument('--replay', default=10000, type=int,
-                        help="change the replay mem size (default: 10000)")
-    parser.add_argument('--priority', default=False, action='store_true',
-                        help='switch for prioritized replay (default: False)')
-    parser.add_argument('--rankbased', default=False, action='store_true',
-                        help='switch for rank-based prioritized replay (omit if proportional)')
-    
+    rl_args = parser.add_argument_group("Model", "Reinforcement learning model parameters")
+    rl_args.add_argument('--learning-rate', default=1e-4, type=float,
+                         help='learning rate (default: 1e-4)')
+    rl_args.add_argument('--state', default='binary', type=str, choices=['binary', 'color'],
+                         help='state representation (default: binary)')
+    rl_args.add_argument('--network', default='dqn_pong_model',
+                         help='choose a network architecture (default: dqn_pong_model)')
+    rl_args.add_argument('--double', default=False, action='store_true',
+                         help='switch for double dqn (default: False)')
+    rl_args.add_argument('--pretrain', default=False, action='store_true',
+                         help='switch for pretrained network (default: False)')
+    rl_args.add_argument('--test', default=False, action='store_true',
+                         help='Run the model without training')
+    rl_args.add_argument('--render', default=False, type=str, choices=['human', 'png'],
+                         help="Rendering mode. Omit if no rendering is desired.")
+    rl_args.add_argument('--epsdecay', default=1000, type=int,
+                         help="epsilon decay (default: 1000)")
+    rl_args.add_argument('--stepsdecay', default=False, action='store_true',
+                         help="switch to use default step decay")
+    rl_args.add_argument('--episodes', dest='episodes', default=4000, type=int,
+                         help='Number of episodes to train for (default: 4000)')
+    rl_args.add_argument('--replay', default=10000, type=int,
+                         help="change the replay mem size (default: 10000)")
+    rl_args.add_argument('--priority', default=False, action='store_true',
+                         help='switch for prioritized replay (default: False)')
+    rl_args.add_argument('--rankbased', default=False, action='store_true',
+                         help='switch for rank-based prioritized replay (omit if proportional)')
+
     '''resume args'''
-    parser.add_argument('--resume', dest='resume', action='store_true',
-                        help='Resume training switch. (omit to start from scratch)')
-    parser.add_argument('--checkpoint', default='dqn_pong_model',
-                        help='Checkpoint to load if resuming (default: dqn_pong_model)')
-    parser.add_argument('--history', default='history.p',
-                        help='History to load if resuming (default: history.p)')
-    parser.add_argument('--store-dir', dest='store_dir',
-                        default=os.path.join('..', 'experiments', time.strftime("%Y-%m-%d %H.%M.%S")),
-                        help='Path to directory to store experiment results (default: ./experiments/<timestamp>/')
+    resume_args = parser.add_argument_group("Resume", "Store experiments / Resume training")
+    resume_args.add_argument('--resume', dest='resume', action='store_true',
+                             help='Resume training switch. (omit to start from scratch)')
+    resume_args.add_argument('--checkpoint', default='dqn_pong_model',
+                             help='Checkpoint to load if resuming (default: dqn_pong_model)')
+    resume_args.add_argument('--history', default='history.p',
+                             help='History to load if resuming (default: history.p)')
+    resume_args.add_argument('--store-dir', dest='store_dir',
+                             default=os.path.join('..', 'experiments', time.strftime("%Y-%m-%d %H.%M.%S")),
+                             help='Path to directory to store experiment results (default: ./experiments/<timestamp>/')
 
     args = parser.parse_args()
 
@@ -343,7 +346,7 @@ if __name__ == '__main__':
     EPS_DECAY = args.epsdecay
     TARGET_UPDATE = 1000
     RENDER = args.render
-    lr = args.lr
+    lr = args.learning_rate
     INITIAL_MEMORY = args.replay
     MEMORY_SIZE = 10 * INITIAL_MEMORY
     DOUBLE = args.double
@@ -372,12 +375,12 @@ if __name__ == '__main__':
         snell_width=args.snell_width,
         snell_change=args.snell_change,
         snell_visible=args.snell_visible,
-        our_paddle_speed=args.ps,
-        their_paddle_speed=args.ps,
-        our_paddle_height=args.pl,
-        their_paddle_height=args.pl,
-        our_paddle_angle=math.radians(args.pa),
-        their_paddle_angle=math.radians(args.pa),
+        our_paddle_speed=args.paddle_speed,
+        their_paddle_speed=args.paddle_speed,
+        our_paddle_height=args.paddle_length,
+        their_paddle_height=args.paddle_length,
+        our_paddle_angle=math.radians(args.paddle_angle),
+        their_paddle_angle=math.radians(args.paddle_angle),
         their_update_probability=args.update_prob,
         ball_size=args.ball_size,
         state_type=args.state,

--- a/utils/dashboard/dashboard.py
+++ b/utils/dashboard/dashboard.py
@@ -13,8 +13,7 @@ import plotly.express as px
 import plotly.graph_objects as go
 from dash.dependencies import Input, Output
 
-from data_loader import get_experiments, get_rewards_history_df, get_steps_history_df
-
+from data_loader import get_experiments, get_rewards_history_df, get_steps_history_df, get_parameters_df
 
 # Initialize app
 app = dash.Dash(__name__, meta_tags=[{"name": "viewport", "content": "width=device-width"}],
@@ -64,6 +63,8 @@ def load_markdown_text(file: str) -> str:
     return md
 
 
+experiments = get_experiments()
+
 # Create app layout
 app.layout = html.Div(
     [
@@ -91,7 +92,7 @@ app.layout = html.Div(
             style={"margin-bottom": "25px"},
         ),
 
-        # Dashboard
+        # Training
         html.Div(
             [
                 html.Div(
@@ -101,24 +102,23 @@ app.layout = html.Div(
                                 "Select experiments:",
                                 dcc.Dropdown(
                                     id='experiment-selector',
-                                    options=get_experiments(),
+                                    options=experiments,
                                     multi=True
                                 ),
                                 html.Br(),
-                                "Moving average length:",
+                                html.P("Moving average length:", id='moving-avg-slider-text'),
                                 dcc.Slider(
                                     id='moving-avg-slider',
                                     min=1,
                                     max=100,
                                     step=1,
                                     value=10,
-                                    tooltip=dict(always_visible=True, placement='bottomLeft'),
                                 ),
                             ]
                         ),
                     ],
                     className='pretty_container three columns',
-                    id='ml_controls',
+                    id='training-div',
                 ),
                 html.Div(
                     [
@@ -131,6 +131,21 @@ app.layout = html.Div(
                         dcc.Graph(id='step-plot')
                     ],
                     className='pretty_container five columns',
+                ),
+            ],
+            className='flex-display',
+            style={'margin-bottom': '25px'}
+        ),
+
+        # Parameters
+        html.Div(
+            [
+                html.Div(
+                    [
+                        dbc.Table(id='experiment-table'),
+                    ],
+                    className='pretty_container twelve columns',
+                    id='params-table-div',
                 ),
             ],
             className='flex-display',
@@ -155,6 +170,27 @@ def get_empty_sunburst(text: str):
         path=['x'],
         hover_data=None
     )
+
+
+@app.callback(
+    Output('experiment-table', 'children'),
+    [Input('experiment-selector', 'value')]
+)
+def make_experiment_table(experiments: List[str]) -> List:
+    if experiments:
+        df = get_parameters_df(experiments)
+        table = dbc.Table.from_dataframe(df, striped=True, bordered=True, hover=True)
+    else:
+        table = get_empty_sunburst('Select and experiment')
+    return [table]
+
+
+@app.callback(
+    Output('moving-avg-slider-text', 'children'),
+    [Input('moving-avg-slider', 'value')]
+)
+def update_moving_avg_slider_text(value: int) -> List:
+    return [f"Moving average length: {value}"]
 
 
 @app.callback(
@@ -199,7 +235,7 @@ if __name__ == '__main__':
     # noinspection PyTypeChecker
     app.run_server(debug=False,
                    dev_tools_hot_reload=False,
-                   # host=os.getenv("HOST", "127.0.0.1"),
-                   host=os.getenv("HOST", "192.168.1.10"),
+                   host=os.getenv("HOST", "127.0.0.1"),
+                   # host=os.getenv("HOST", "192.168.1.10"),
                    port=os.getenv("PORT", "8050"),
                    )

--- a/utils/dashboard/dashboard.py
+++ b/utils/dashboard/dashboard.py
@@ -233,7 +233,7 @@ def get_step_plot(experiments: List[str], moving_avg_len) -> go.Figure:
 
 if __name__ == '__main__':
     # noinspection PyTypeChecker
-    app.run_server(debug=False,
+    app.run_server(debug=True,
                    dev_tools_hot_reload=False,
                    host=os.getenv("HOST", "127.0.0.1"),
                    # host=os.getenv("HOST", "192.168.1.10"),

--- a/utils/dashboard/dashboard.py
+++ b/utils/dashboard/dashboard.py
@@ -9,6 +9,7 @@ import dash
 import dash_bootstrap_components as dbc
 import dash_core_components as dcc
 import dash_html_components as html
+import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 from dash.dependencies import Input, Output
@@ -144,7 +145,6 @@ app.layout = html.Div(
                     [
                         dbc.Table(id='experiment-table'),
                     ],
-                    className='pretty_container twelve columns',
                     id='params-table-div',
                 ),
             ],
@@ -181,8 +181,8 @@ def make_experiment_table(experiments: List[str]) -> List:
         df = get_parameters_df(experiments)
         table = dbc.Table.from_dataframe(df, striped=True, bordered=True, hover=True)
     else:
-        table = get_empty_sunburst('Select and experiment')
-    return [table]
+        table = dbc.Table.from_dataframe(pd.DataFrame())
+    return table
 
 
 @app.callback(

--- a/utils/dashboard/data_loader.py
+++ b/utils/dashboard/data_loader.py
@@ -30,7 +30,8 @@ def get_experiments() -> List[Dict]:
     :return: List of experiments
     """
     experiments_root = os.path.join(root_dir, 'experiments')
-    return [{'label': e, 'value': e} for e in os.listdir(experiments_root)]
+    experiments = [{'label': e, 'value': e} for e in os.listdir(experiments_root)]
+    return sorted(experiments, key=lambda x: x['label'])
 
 
 def get_multi_index_history_df(experiments: List[str]) -> pd.DataFrame:

--- a/utils/dashboard/data_loader.py
+++ b/utils/dashboard/data_loader.py
@@ -110,11 +110,12 @@ def get_steps_history_df(experiments: List[str], moving_avg_len=1) -> pd.DataFra
 def get_parameters_df(experiments: List[str]):
     df = pd.DataFrame()
     for e in experiments:
+        params_dict = dict(experiment=e)
         with open(os.path.join(root_dir, 'experiments', e, 'output.log')) as f:
-            params_dict = _parse_parameters(f.readline())
+            params_dict.update(_parse_parameters(f.readline()))
         params_df = pd.DataFrame(params_dict, index=[e])
 
-        df = pd.concat([df, params_df], axis=1)
+        df = pd.concat([df, params_df], axis=0, join='outer')
     return df
 
 


### PR DESCRIPTION
The script reads the experiment parameters from `experiments/<experiment>/output.log`. The parameters were not stored for some of the earlier experiments.

Also added some grouping for the main parameters to better organize the output of `--help`